### PR TITLE
添加了Openwrt自启动服务版；优化排版

### DIFF
--- a/docs/version.md
+++ b/docs/version.md
@@ -1,23 +1,29 @@
 # 校园网登陆器版本
 
 
-- 电脑版本
-  - <a href="https://static.ffis.me/srun3k/srun3k-pc.7z">电脑Qt版（Windows)</a>
-  - <a href="https://github.com/ehaut/EhautX">电脑MAC版(Mac)</a> 
-  - <a href="../srun/srun3k-new.html">网页版(全平台在线访问）</a>
-  - <a href="https://raw.githubusercontent.com/ehaut/ehaut/master/download/lastest.zip">网页版(离线版)</a>
+- PC
+  - [电脑Qt版（Windows)](https://static.ffis.me/srun3k/srun3k-pc.7z)
 
-- 手机版本
-  - <a href="https://www.icloud.com/shortcuts/f6612a29f8cd4be891fe5766f157c02a">手机IOS快捷指令版</a>
-  - <a href="https://itunes.apple.com/cn/app/%E6%B2%B3%E5%8D%97%E5%B7%A5%E4%B8%9A%E5%A4%A7%E5%AD%A6%E6%A0%A1%E5%9B%AD%E7%BD%91%E7%99%BB%E5%BD%95%E5%99%A8/id1435094667?mt=8">手机IOS版</a>
-  - <a href="https://static.ffis.me/srun3k/new.apk">手机安卓版</a>
+- Mac
+  - [EHautX](https://github.com/ehaut/EhautX)
 
-- 命令行版本
-  - <a href="https://github.com/ehaut/srun3k-client-cli">命令行Python版</a> 
-  - <a href="https://github.com/rainvalley/Srun_Linux/blob/master/srun.sh">Bash版</a> 
+- Web
+  - [在线版（全平台）](../srun/srun3k-new.htm)
+  - [离线版](https://raw.githubusercontent.com/ehaut/ehaut/master/download/lastest.zip)
 
-- 路由器版本
-  - <a href="https://github.com/ehaut/autologin-srun3k">OpenWrt 路由器</a> 
+- 移动端
+  - [iOS快捷指令](https://www.icloud.com/shortcuts/f6612a29f8cd4be891fe5766f157c02a)
+  - [iOS App](https://itunes.apple.com/cn/app/%E6%B2%B3%E5%8D%97%E5%B7%A5%E4%B8%9A%E5%A4%A7%E5%AD%A6%E6%A0%A1%E5%9B%AD%E7%BD%91%E7%99%BB%E5%BD%95%E5%99%A8/id1435094667?mt=8)
+  - [Android App](https://static.ffis.me/srun3k/new.apk)
 
-- NodeMCU版本
-  - <a href="https://github.com/chillsoul/ESP8266-Srun3kAutoLogin">ESP8266</a> 
+- cli
+  - [Python版](https://github.com/ehaut/srun3k-client-cli)
+  - [bash版](https://github.com/rainvalley/Srun_Linux/)
+
+- 路由器(Openwrt)
+  - [Openwrt自启动服务版](https://github.com/CHxCOOH/Srun_Openwrt)
+  - [bash版](https://github.com/rainvalley/Srun_Linux/)
+  - [Openwrt Python](https://github.com/ehaut/autologin-srun3k)
+
+- NodeMCU
+  - [ESP8266](https://github.com/chillsoul/ESP8266-Srun3kAutoLogin)


### PR DESCRIPTION
近期校园网又开启了多设备登录限制，掉线频率高了不少。在防多设备检测的过程中，正好在 bash 版基础上写了这个适用于 Openwrt 的版本。现在这个版本可以每 5s 检测一次登录状态，并自动登录了。